### PR TITLE
Update ga layers 2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "pwa-node",
+            "request": "launch",
+            "name": "Launch Program",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "program": "${workspaceFolder}\\natmap\\build.js"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ Run
 
 which will produce catalog file `natmap/out.json`. Please upload this file to the `s3` bucket with different name to be used by national map config.
 
+**Catalogue history**
 | *s3 file name* | *commit version* |
 |----------------|------------------|
-| natmap-2021-02-10-v8.json | 5c89cb54f73d4cab4cf5f079d0151ac5f7822a1b |
+| natmap-2021-02-10-v8.json | 9c1194b45b7e77df7e40efd9aae94e86a97e95f6 |
 
 ## Deploy
  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Run
 
 which will produce catalog file `natmap/out.json`. Please upload this file to the `s3` bucket with different name to be used by national map config.
 
+| *s3 file name* | *commit version* |
+|----------------|------------------|
+| natmap-2021-02-10-v8.json | 5c89cb54f73d4cab4cf5f079d0151ac5f7822a1b |
+
 ## Deploy
  
  Currently, we are storing NationalMap catalogs at https://tiles.terria.io/static/natmap-prod-2021-02-01-1406-converted-v8.json, 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,22 @@ This approach is not ideal, but will let you see changes using a diff-tool. Thes
  
 **Note:** `natmap/root.js` uses `natmap\in\aremi-2020-09-22-v8-with-mods.json`. So manual modifications are only needed when you update AREMI catalog.
   
- ## Deploy
+### Add new datasets from GA
+`National Datasets` are added 9 datasets as described by `catalog` in file `./natmap/in/manual-v8-catalogs/ga-new-layers-v8.json`. You can directly drag-and-drop this
+json file to the NationalMap to verify if they work correctly. Each member in the `catalog` array has a property `catalogPath` that tells `root.js` where to add this
+member.
+
+### Generate a complete catalog json file
+Run
+
+```
+  cd natmap
+  node build.js
+```
+
+which will produce catalog file `natmap/out.json`. Please upload this file to the `s3` bucket with different name to be used by national map config.
+
+## Deploy
  
  Currently, we are storing NationalMap catalogs at https://tiles.terria.io/static/natmap-prod-2021-02-01-1406-converted-v8.json, 
  which is an S3 bucket here - https://s3.console.aws.amazon.com/s3/buckets/tiles.terria.io?region=ap-southeast-2&prefix=static/

--- a/natmap/in/manual-v8-catalogs/ga-new-layers-v8.json
+++ b/natmap/in/manual-v8-catalogs/ga-new-layers-v8.json
@@ -1,0 +1,95 @@
+{
+  "catalog":
+  [
+    {
+      "type": "esri-mapServer",
+      "name": "Australian Shoreline",
+      "catalogPath": ["Boundaries", "Maritime boundaries"],
+      "url": "https://services.ga.gov.au/gis/rest/services/Australian_Shoreline/MapServer",
+      "id": "kdFawos",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Maritime boundaries/Australian Shoreline"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "Surface Hydrology",
+      "catalogPath": ["Water", "Surface Water", "Individual Hydrology and Marine Layers"],
+      "url": "https://services.ga.gov.au/gis/rest/services/Surface_Hydrology/MapServer",
+      "id": "aiIUaag",
+      "shareKeys": [
+        "Root Group/National Datasets/Water/Surface Water/Individual Hydrology and Marine Layers/Surface Hydrology"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "Australian Maritime Boundary Treaties AMB2014a",
+      "catalogPath": ["Boundaries", "Maritime boundaries"],
+      "url": "https://services.ga.gov.au/gis/rest/services/Treaties_Australian_Maritime_Boundaries_AMB2014a/MapServer",
+      "id": "auTWEww",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Maritime boundaries/Australian Maritime Boundary Treaties AMB2014a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "CWTH CW Act 1980 Coastal Waters AMB2014a",
+      "catalogPath": ["Boundaries", "Maritime boundaries"],
+      "url": "https://services.ga.gov.au/gis/rest/services/CW_1970_1980_AMB2014a/MapServer",
+      "id": "sjuAErs",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Maritime boundaries/CWTH CW Act 1980 Coastal Waters AMB2014a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "CWTH OMA 1994 Mineral Blocks AMB2014a",
+      "catalogPath": ["Boundaries", "Other areas"],
+      "url": "https://services.ga.gov.au/gis/rest/services/OMA_1994_Mineral_Blocks_AMB2014a/MapServer",
+      "id": "pUTdjtT",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Other areas/CWTH OMA 1994 Mineral Blocks AMB2014a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "CWTH OPGGSA 2006 Petroleum Blocks AMB2001a",
+      "catalogPath": ["Boundaries", "Other areas"],
+      "url": "https://services.ga.gov.au/gis/rest/services/CWTH_OPGGSA_2006_Petroleum_Blocks_AMB2001a/MapServer",
+      "id": "pduSsJS",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Other areas/CWTH OPGGSA 2006 Petroleum Blocks AMB2001a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "CWTH OPGGSA 2006 Petroleum Blocks AMB2014a",
+      "catalogPath": ["Boundaries", "Other areas"],
+      "url": "https://services.ga.gov.au/gis/rest/services/OPGGSA_2006_Petroleum_Blocks_AMB2014a/MapServer",
+      "id": "EyRYwed",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Other areas/CWTH OPGGSA 2006 Petroleum Blocks AMB2014a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "CWTH OPGGSA 2006 AMB2014a",
+      "catalogPath": ["Boundaries", "Other areas"],
+      "url": "https://services.ga.gov.au/gis/rest/services/OPGGSA_2006_Areas_AMB2014a/MapServer",
+      "id": "ERYawyB",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Other areas/CWTH OPGGSA 2006 AMB2014a"
+      ]
+    },
+    {
+      "type": "esri-mapServer",
+      "name": "SSLA 1973 AMB2014a",
+      "catalogPath": ["Boundaries", "Other areas"],
+      "url": "https://services.ga.gov.au/gis/rest/services/SSLA_1973_AMB2014a/MapServer",
+      "id": "GHutFsD",
+      "shareKeys": [
+        "Root Group/National Datasets/Boundaries/Other areas/SSLA 1973 AMB2014a"
+      ]
+    }
+  ]
+}

--- a/natmap/root.js
+++ b/natmap/root.js
@@ -413,6 +413,7 @@ gaNewLayers["catalog"].map(m => {
   const group = findInMembers(NationalDatasets.members, path);
   delete m.catalogPath;
   group.members.push(m);
+  group.members = recursivelySortMembersByName(group.members);
 })
 
 // Data.gov.au

--- a/natmap/root.js
+++ b/natmap/root.js
@@ -6,6 +6,7 @@ const recursivelySortMembersByName = require("../helpers/recursivelySortMembersB
 const natmap20200903v8 = require("./in/natmap-2020-09-03-v8.json");
 const aremi20200922v8 = require("./in/aremi-2020-09-22-v8-with-mods.json");
 const aremiEvTraffic = require("./in/manual-v8-catalogs/aremi-traffic-v8.json");
+const gaNewLayers = require("./in/manual-v8-catalogs/ga-new-layers-v8.json");
 
 // remove "Land Use" subgroup from Agriculture
 const Agriculture = cloneFromCatalogPath(natmap20200903v8, [
@@ -14,7 +15,12 @@ const Agriculture = cloneFromCatalogPath(natmap20200903v8, [
 ]);
 Agriculture.members = Agriculture.members.filter(
   (m) => m.name !== "Land Use and Cover in South Australia"
-);
+).map(m => {
+  if (m.name === "Agricultural Exposure"){
+    m.url = "https://services.ga.gov.au/gis/rest/services/Australian_Exposure_Information/MapServer";
+  }
+  return m;
+});
 
 // remove ABC Photo Stories from Communications
 const Communications = cloneFromCatalogPath(natmap20200903v8, [
@@ -265,7 +271,7 @@ Boundaries.members = [
     ],
   },
   {
-    name: "Other areas ",
+    name: "Other areas",
     type: "group",
     members: [
       findInMembers(Boundaries.members, ["Postal Areas (2011)"]),
@@ -401,6 +407,13 @@ NationalDatasets.members = recursivelySortMembersByName([
   Vegetation,
   Water,
 ]);
+
+gaNewLayers["catalog"].map(m => {
+  const path = m.catalogPath;
+  const group = findInMembers(NationalDatasets.members, path);
+  delete m.catalogPath;
+  group.members.push(m);
+})
 
 // Data.gov.au
 const DGA = cloneFromCatalogPath(natmap20200903v8, ["Data.gov.au"]);


### PR DESCRIPTION
Address issue https://github.com/TerriaJS/nationalmap/issues/986

https://tiles.terria.io/static/natmap-2021-02-10-v8.json is now used by https://nationalmap.dev.saas.terria.io
The updated or newly added datasets can be viewed by:
- https://nationalmap.dev.saas.terria.io/#share=s-p8myCer7gr4bqRxjLd8TBgGjSqI (1 dataset)
- https://nationalmap.dev.saas.terria.io/#share=s-dTZBuV7XwdmI9m5anLOkyadutyr (3 datasets)
- https://nationalmap.dev.saas.terria.io/#share=s-9y65D9v9zbaD9eAM3skTWmU9vhY (5 datasets)
- https://nationalmap.dev.saas.terria.io/#share=s-zWJ3TIrCrOC7CLapZU1etAEcKL7 (1 dataset)

@AnaBelgun I choose to add the new datasets to those groups. Please advise if the choices are OK.
