### PR TITLE
Update urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ which will produce catalog file `natmap/out.json`. Please upload this file to th
 | natmap-2021-04-14-v8.json | 128bf155564c009ff091b84efd8445271e1e8289 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
+| natmap-2021-05-11-v8.json | tba |
 
 **Catalogue history (in GitHub)**
 | *catalog commit* | *this repo commit* |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ which will produce catalog file `natmap/out.json`. Please upload this file to th
 | natmap-2021-04-14-v8.json | 128bf155564c009ff091b84efd8445271e1e8289 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
-| natmap-2021-05-11-v8.json | tba |
+| natmap-2021-05-11-v8.json | d9b4efd2c28ca4135b9a6dccad9ac52e7eb6d1b5 |
 
 **Catalogue history (in GitHub)**
 | *catalog commit* | *this repo commit* |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ which will produce catalog file `natmap/out.json`. Please upload this file to th
 | natmap-2021-04-14-v8.json | 128bf155564c009ff091b84efd8445271e1e8289 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
 | natmap-2021-04-16-v8.json | 3bd209bebcf2446715ea131ed4e52a5faf825dc5 |
-| natmap-2021-05-11-v8.json | d9b4efd2c28ca4135b9a6dccad9ac52e7eb6d1b5 |
+| natmap-2021-05-12-v8.json | d9b4efd2c28ca4135b9a6dccad9ac52e7eb6d1b5 |
 
 **Catalogue history (in GitHub)**
 | *catalog commit* | *this repo commit* |

--- a/natmap/root.js
+++ b/natmap/root.js
@@ -97,6 +97,10 @@ Communications.members = Communications.members
   .filter((m) => m.name !== "ABC Photo Stories (2009-2014)")
   .filter((m) => m.name !== "ABC Photo Stories by date");
 
+const RadionLicenses = findInMembers(Communications.members, ["Radio Licenses - ACMA"]);
+RadionLicenses.url = RadionLicenses.url.replace("http://", "https://");
+RadionLicenses.legends = undefined;
+
 // Elevation
 // move Terrain subgroup from Land Cover
 const Terrain = cloneFromCatalogPath(natmap20200903v8, [
@@ -264,6 +268,8 @@ Cemeteries.layers = "Cemetery_Areas,Cemetery_Points"; // fix bad MapServer requi
 Habitation.members = Habitation.members.filter(
   (m) => m.name !== "Cemetery Areas"
 );
+
+findInMembers(Habitation.members, ["Australia Post Locations"]).url = "https://tiles.terria.io/static/auspost-locations.csv";
 
 // Health group
 const Health = cloneFromCatalogPath(natmap20200903v8, [


### PR DESCRIPTION
Address #20 

1. Replace http with https in "Radio Licenses ACMA" url. Also remove its "legends" property as the referenced host does not exist. Otherwise it will cause error 500 (seen in console log).
2. "Australia Post Locations" url is updated so that it can retreat underneath data successfully.

The changes can be verified in dev.
- https://nationalmap.dev.saas.terria.io/#share=s-bntE77HcaQYqtu8SHmhHofmF7dK ~-- Ha, this one works in Firefox but not in Chrome! Besides, it works with drag-and-drop in Chrome. Anything to do with async loader?~
  However, after exploring the items in the map for a while, the following error message pops out. It seems like a false alarm.
  
![image](https://user-images.githubusercontent.com/41275384/118059346-adc87900-b3d3-11eb-8ca2-0ca4e4db69c4.png)

  The same dataset in DT Vic does not cause the error https://dev.vic.digitaltwin.terria.io/#share=s-2D3a85NPlbN8jg6h93RfPGiuw9S. The difference is that the nationalmap proxies the request while DT Vic does not.
- https://nationalmap.dev.saas.terria.io/#share=s-2xpsFIUnLkRJQhH62rJ1e29eFEB